### PR TITLE
feat: Implement initial AppZap application

### DIFF
--- a/cgi-bin/sysinfo.py
+++ b/cgi-bin/sysinfo.py
@@ -1,103 +1,210 @@
 #!/usr/bin/env python3
-"""CGI script providing process information and control endpoints."""
 
 import cgi
-import cgitb
 import json
-import os
 import psutil
-from pathlib import Path
+import os
+import signal # For os.kill
 
-cgitb.enable()  # for debugging
+# Path for the kill list JSON file.
+KILL_LIST_FILE = os.path.join(os.path.dirname(__file__), "kill_list.json")
 
-KILL_LIST_PATH = Path(__file__).with_name('kill_list.json')
+def get_process_info():
+    """Gathers detailed information about running processes."""
+    processes = []
+    for proc in psutil.process_iter(['pid', 'name', 'cmdline', 'cpu_percent', 'memory_percent', 'io_counters', 'ppid', 'username']):
+        try:
+            try:
+                net_io = proc.io_counters()
+                net_in = net_io.read_bytes
+                net_out = net_io.write_bytes
+            except (FileNotFoundError, psutil.AccessDenied, psutil.Error):
+                net_in = 0
+                net_out = 0
 
+            processes.append({
+                'pid': proc.info['pid'],
+                'name': proc.info['name'],
+                'cmdline': ' '.join(proc.info['cmdline']) if proc.info['cmdline'] else '',
+                'cpu_percent': proc.info['cpu_percent'],
+                'memory_percent': proc.info['memory_percent'],
+                'net_in': net_in,
+                'net_out': net_out,
+                'ppid': proc.info['ppid'],
+                'user': proc.info['username']
+            })
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+    return processes
 
 def load_kill_list():
-    if KILL_LIST_PATH.exists():
-        with open(KILL_LIST_PATH) as f:
-            try:
-                return json.load(f)
-            except json.JSONDecodeError:
-                return []
-    return []
-
-
-def save_kill_list(kill_list):
-    with open(KILL_LIST_PATH, 'w') as f:
-        json.dump(kill_list, f)
-
-
-def list_processes():
-    procs = []
-    for p in psutil.process_iter(['pid', 'name', 'username', 'cpu_percent', 'memory_percent', 'ppid']):
-        try:
-            info = p.info
-            procs.append({
-                'pid': info['pid'],
-                'name': info['name'],
-                'cpu_percent': info['cpu_percent'],
-                'memory_percent': info['memory_percent'],
-                'ppid': info['ppid'],
-                'user': info['username'],
-            })
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            continue
-    return procs
-
-
-def kill_process(pid: int):
+    """Loads the list of PIDs from kill_list.json."""
+    if not os.path.exists(KILL_LIST_FILE):
+        return []
     try:
-        p = psutil.Process(pid)
-        p.kill()
+        with open(KILL_LIST_FILE, 'r') as f:
+            data = json.load(f)
+            if isinstance(data, list) and all(isinstance(pid, int) for pid in data):
+                return data
+            # If data is not a list of integers, treat as invalid.
+            return []
+    except (IOError, json.JSONDecodeError):
+        return []
+
+def save_kill_list(pids):
+    """Saves the list of PIDs to kill_list.json."""
+    try:
+        # Ensure all PIDs are integers before saving
+        valid_pids = [pid for pid in pids if isinstance(pid, int)]
+        with open(KILL_LIST_FILE, 'w') as f:
+            json.dump(valid_pids, f, indent=4)
         return True
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
+    except (IOError, TypeError):
         return False
 
+def sanitize_pid(pid_str):
+    """Converts PID string to integer, returns None on failure."""
+    if pid_str is None:
+        return None
+    try:
+        return int(pid_str)
+    except ValueError:
+        return None
 
-def handle_action(action, form):
-    if action == 'list':
-        return {'processes': list_processes()}
+def action_kill_process(pid_str):
+    """Attempts to kill a process by its PID."""
+    pid = sanitize_pid(pid_str)
+    if pid is None:
+        return {'status': 'error', 'message': 'Invalid or missing PID.'}
 
-    elif action == 'kill':
-        pid = int(form.getfirst('pid', '-1'))
-        success = kill_process(pid)
-        return {'killed': success, 'pid': pid}
+    try:
+        proc = psutil.Process(pid)
+        proc.kill()
+        return {'status': 'success', 'message': f'Signal sent to kill process {pid}.'}
+    except psutil.NoSuchProcess:
+        return {'status': 'error', 'message': f'Process {pid} not found.'}
+    except psutil.AccessDenied:
+        return {'status': 'error', 'message': f'Access denied to kill process {pid}.'}
+    except Exception as e:
+        return {'status': 'error', 'message': f'Failed to kill process {pid}: {str(e)}'}
 
-    elif action == 'add_kill_list':
-        pid = int(form.getfirst('pid', '-1'))
-        kill_list = load_kill_list()
-        if pid not in kill_list:
-            kill_list.append(pid)
-            save_kill_list(kill_list)
-        return {'kill_list': kill_list}
+def action_add_to_kill_list(pid_str):
+    """Adds a PID to the kill list."""
+    pid = sanitize_pid(pid_str)
+    if pid is None:
+        return {'status': 'error', 'message': 'Invalid or missing PID.'}
 
-    elif action == 'remove_kill_list':
-        pid = int(form.getfirst('pid', '-1'))
-        kill_list = load_kill_list()
-        if pid in kill_list:
-            kill_list.remove(pid)
-            save_kill_list(kill_list)
-        return {'kill_list': kill_list}
+    pids = load_kill_list()
+    if pid not in pids:
+        pids.append(pid)
+        if save_kill_list(pids):
+            return {'status': 'success', 'message': f'PID {pid} added to kill list.'}
+        else:
+            return {'status': 'error', 'message': 'Failed to save kill list.'}
+    else:
+        return {'status': 'success', 'message': f'PID {pid} already in kill list.'}
 
-    elif action == 'kill_loop_check':
-        kill_list = load_kill_list()
-        killed = []
-        for pid in list(kill_list):
-            if kill_process(pid):
-                killed.append(pid)
-        return {'killed': killed}
+def action_remove_from_kill_list(pid_str):
+    """Removes a PID from the kill list."""
+    pid = sanitize_pid(pid_str)
+    if pid is None:
+        return {'status': 'error', 'message': 'Invalid or missing PID.'}
 
-    return {'error': 'unknown action'}
+    pids = load_kill_list()
+    if pid in pids:
+        pids.remove(pid)
+        if save_kill_list(pids):
+            return {'status': 'success', 'message': f'PID {pid} removed from kill list.'}
+        else:
+            return {'status': 'error', 'message': 'Failed to save kill list.'}
+    else:
+        return {'status': 'error', 'message': f'PID {pid} not found in kill list.'}
 
+def action_kill_loop_check():
+    """Checks kill_list.json and attempts to kill listed running processes."""
+    pids_to_kill = load_kill_list()
+    results = []
+    updated_pids = list(pids_to_kill)
+
+    if not pids_to_kill:
+        return {'status': 'success', 'message': 'Kill list is empty.', 'results': []}
+
+    for pid_val in pids_to_kill: # Renamed pid to pid_val to avoid conflict with module
+        try:
+            if psutil.pid_exists(pid_val):
+                proc = psutil.Process(pid_val)
+                proc_name = proc.name() # Get name before kill, in case of quick termination
+                proc.kill()
+                results.append({'pid': pid_val, 'status': 'killed', 'name': proc_name})
+            else:
+                results.append({'pid': pid_val, 'status': 'not_found'})
+                if pid_val in updated_pids:
+                    updated_pids.remove(pid_val)
+        except psutil.AccessDenied:
+            proc_name_ad = 'N/A'
+            try:
+                if psutil.pid_exists(pid_val):
+                    proc_name_ad = psutil.Process(pid_val).name()
+            except psutil.Error: # Catch errors if process disappears during check
+                pass
+            results.append({'pid': pid_val, 'status': 'access_denied', 'name': proc_name_ad})
+        except psutil.NoSuchProcess:
+            results.append({'pid': pid_val, 'status': 'not_found_on_kill_attempt'})
+            if pid_val in updated_pids:
+                 updated_pids.remove(pid_val)
+        except Exception as e:
+            results.append({'pid': pid_val, 'status': 'error', 'message': str(e)})
+
+    save_kill_list(updated_pids)
+    return {'status': 'success', 'message': 'Kill loop check completed.', 'results': results}
+
+def action_list_kill_list():
+    """Loads and returns the kill list."""
+    # load_kill_list() already handles file not existing, JSON errors, and returns []
+    pids = load_kill_list()
+    return {'status': 'success', 'pids': pids}
 
 def main():
+    """Handles incoming CGI requests."""
+    print("Content-Type: application/json")
+    print() # End of headers
+
     form = cgi.FieldStorage()
-    action = form.getfirst('action', 'list')
-    result = handle_action(action, form)
-    print('Content-Type: application/json\n')
-    print(json.dumps(result))
+    action = form.getvalue("action")
+    pid_str = form.getvalue("pid")
 
+    response = {}
+    supported_actions = ["list", "kill", "add_kill_list", "remove_kill_list", "kill_loop_check", "list_kill_list"]
 
-if __name__ == '__main__':
+    if action == "list":
+        try:
+            response['status'] = 'success'
+            response['processes'] = get_process_info()
+        except Exception as e:
+            response['status'] = 'error'
+            response['message'] = f"An error occurred while listing processes: {str(e)}"
+    elif action == "kill":
+        response = action_kill_process(pid_str)
+    elif action == "add_kill_list":
+        response = action_add_to_kill_list(pid_str)
+    elif action == "remove_kill_list":
+        response = action_remove_from_kill_list(pid_str)
+    elif action == "kill_loop_check":
+        response = action_kill_loop_check()
+    elif action == "list_kill_list": # New action
+        response = action_list_kill_list()
+    elif action is None:
+        response['status'] = 'error'
+        response['message'] = f'Action parameter missing. Supported actions: "{", ".join(supported_actions)}"'
+    else:
+        response['status'] = 'error'
+        response['message'] = f'Invalid action "{action}". Supported actions: "{", ".join(supported_actions)}"'
+
+    try:
+        print(json.dumps(response, indent=4))
+    except Exception as e:
+        # Fallback for critical JSON errors, should not happen with current responses
+        print(json.dumps({'status': 'error', 'message': f'Critical JSON serialization error: {str(e)}'}))
+
+if __name__ == "__main__":
     main()

--- a/static/app.js
+++ b/static/app.js
@@ -1,38 +1,277 @@
-async function fetchProcesses() {
-    const res = await fetch('../cgi-bin/sysinfo.py?action=list');
-    const data = await res.json();
-    renderTable(data.processes);
-}
-
-function renderTable(processes) {
-    const tbody = document.querySelector('#proc-table tbody');
-    tbody.innerHTML = '';
-    processes.forEach(proc => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `
-            <td>${proc.pid}</td>
-            <td>${proc.name}</td>
-            <td>${proc.cpu_percent}</td>
-            <td>${proc.memory_percent.toFixed(1)}</td>
-            <td>${proc.user}</td>
-            <td><button class="kill" data-pid="${proc.pid}">✖</button></td>`;
-        tbody.appendChild(tr);
-    });
-}
-
-async function killPid(pid) {
-    await fetch(`../cgi-bin/sysinfo.py?action=kill&pid=${pid}`);
-    fetchProcesses();
-}
-
-document.addEventListener('click', e => {
-    if (e.target.matches('button.kill')) {
-        const pid = e.target.getAttribute('data-pid');
-        killPid(pid);
-    }
-});
-
 document.addEventListener('DOMContentLoaded', () => {
+    const API_ENDPOINT = '/cgi-bin/sysinfo.py';
+    const REFRESH_INTERVAL = 7000; // 7 seconds
+
+    // DOM Elements
+    const processTableBody = document.getElementById('process-list-body');
+    const processStatusMessage = document.getElementById('process-status-message');
+    const refreshProcessesBtn = document.getElementById('refresh-processes-btn');
+
+    const openKillListModalBtn = document.getElementById('open-kill-list-modal-btn');
+    const closeKillListModalBtn = document.getElementById('close-kill-list-modal-btn');
+    const killListModal = document.getElementById('kill-list-modal');
+    const killListBody = document.getElementById('kill-list-body');
+    const killListStatusMessage = document.getElementById('kill-list-status-message');
+
+    const triggerKillLoopBtn = document.getElementById('trigger-kill-loop-btn');
+    const killLoopStatusOutput = document.getElementById('kill-loop-status-output');
+
+    // Helper to update status messages
+    function updateStatus(element, message, statusClass) {
+        if (element) {
+            element.textContent = message;
+            element.className = statusClass; // Applies one class, removes others
+        }
+    }
+
+    // --- Helper for API Requests ---
+    async function apiRequest(action, params = {}) {
+        const queryParams = new URLSearchParams(params);
+        const url = `${API_ENDPOINT}?action=${encodeURIComponent(action)}&${queryParams.toString()}`;
+        try {
+            const response = await fetch(url);
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+            }
+            const data = await response.json();
+            if (data.status === 'error') {
+                throw new Error(data.message || `API returned an error for action ${action}`);
+            }
+            return data;
+        } catch (error) {
+            console.error(`API request failed for action ${action} with params ${JSON.stringify(params)}:`, error);
+            // General API errors update the main process status message.
+            // Specific functions might override this for their local status messages if needed.
+            updateStatus(processStatusMessage, `Network or server error: ${error.message}`, 'status-error');
+            throw error;
+        }
+    }
+
+    // --- Process Management ---
+    function renderProcessTable(processes) {
+        if (!processTableBody) {
+            console.error("Process table body not found");
+            return;
+        }
+        processTableBody.innerHTML = '';
+
+        if (!processes || processes.length === 0) {
+            const colspan = processTableBody.closest('table')?.querySelector('thead tr')?.cells.length || 9;
+            processTableBody.innerHTML = `<tr><td colspan="${colspan}">No processes found or an error occurred.</td></tr>`;
+            // processStatusMessage is handled by fetchProcesses
+            return;
+        }
+
+        processes.forEach(proc => {
+            const row = processTableBody.insertRow();
+            if (proc.user === 'root') {
+                row.classList.add('process-row-system');
+            }
+
+            row.insertCell().textContent = proc.name || 'N/A';
+            row.insertCell().textContent = proc.pid;
+            row.insertCell().textContent = proc.user || 'N/A';
+            row.insertCell().textContent = proc.cpu_percent !== undefined ? proc.cpu_percent.toFixed(2) : 'N/A';
+            row.insertCell().textContent = proc.memory_percent !== undefined ? proc.memory_percent.toFixed(2) : 'N/A';
+            const netIO = `In: ${(proc.net_in / 1024).toFixed(2)} / Out: ${(proc.net_out / 1024).toFixed(2)}`;
+            row.insertCell().textContent = netIO;
+            row.insertCell().textContent = proc.ppid || 'N/A';
+            row.insertCell().textContent = proc.cmdline || 'N/A';
+
+            const actionsCell = row.insertCell();
+            const killBtn = document.createElement('button');
+            killBtn.textContent = '✖ Kill';
+            killBtn.classList.add('action-btn', 'kill-btn');
+            killBtn.title = `Kill process ${proc.pid}`;
+            killBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                killProcess(proc.pid, proc.name, row);
+            });
+            actionsCell.appendChild(killBtn);
+
+            const addToKillListBtn = document.createElement('button');
+            addToKillListBtn.textContent = '+ To Kill List';
+            addToKillListBtn.classList.add('action-btn', 'add-kill-list-btn');
+            addToKillListBtn.title = `Add process ${proc.pid} to kill list`;
+            addToKillListBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                addToKillList(proc.pid, row);
+            });
+            actionsCell.appendChild(addToKillListBtn);
+        });
+    }
+
+    async function fetchProcesses() {
+        updateStatus(processStatusMessage, 'Loading processes...', 'status-loading');
+        try {
+            const data = await apiRequest('list');
+            renderProcessTable(data.processes);
+            updateStatus(processStatusMessage, 'Processes loaded successfully.', 'status-success');
+        } catch (error) {
+            renderProcessTable([]);
+            // Error message is set by apiRequest's catch block for processStatusMessage
+        }
+    }
+
+    function brieflyHighlightRow(row, className) {
+        if (!row) return;
+        row.classList.add(className);
+        setTimeout(() => {
+            row.classList.remove(className);
+        }, 1500);
+    }
+
+    async function killProcess(pid, name = 'this process', rowElement) {
+        if (!confirm(`Are you sure you want to send a kill signal to process ${pid} (${name})?`)) return;
+        try {
+            const data = await apiRequest('kill', { pid });
+            updateStatus(processStatusMessage, data.message || `Kill signal sent to process ${pid}.`, 'status-success');
+            brieflyHighlightRow(rowElement, 'row-highlight-error');
+            fetchProcesses();
+        } catch (error) {
+            // apiRequest's catch will update processStatusMessage for general errors.
+            // If a more specific message is needed here for kill-specific API errors (that are not network errors):
+            // updateStatus(processStatusMessage, `Error killing process ${pid}: ${error.message}`, 'status-error');
+        }
+    }
+
+    async function addToKillList(pid, rowElement) {
+        try {
+            const data = await apiRequest('add_kill_list', { pid });
+            updateStatus(processStatusMessage, data.message || `Process ${pid} added to kill list.`, 'status-success');
+            brieflyHighlightRow(rowElement, 'row-highlight-info');
+            if (killListModal && killListModal.style.display === 'block') {
+                loadAndRenderKillList();
+            }
+        } catch (error) {
+            // apiRequest's catch will update processStatusMessage.
+            // updateStatus(processStatusMessage, `Error adding process ${pid} to kill list: ${error.message}`, 'status-error');
+        }
+    }
+
+    // --- Kill List Modal ---
+    function renderKillListTable(pids) {
+        if (!killListBody) {
+            console.error("Kill list table body not found");
+            return;
+        }
+        killListBody.innerHTML = '';
+
+        if (!pids || pids.length === 0) {
+            const colspan = killListBody.closest('table')?.querySelector('thead tr')?.cells.length || 2;
+            killListBody.innerHTML = `<tr><td colspan="${colspan}">Kill list is empty or could not be loaded.</td></tr>`;
+            // killListStatusMessage is handled by loadAndRenderKillList
+            return;
+        }
+
+        pids.forEach(pid => {
+            const row = killListBody.insertRow();
+            row.insertCell().textContent = pid;
+
+            const removeCell = row.insertCell();
+            const removeBtn = document.createElement('button');
+            removeBtn.textContent = 'Remove';
+            removeBtn.classList.add('action-btn', 'remove-kill-list-btn');
+            removeBtn.title = `Remove PID ${pid} from kill list`;
+            removeBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                removeFromKillList(pid, row);
+            });
+            removeCell.appendChild(removeBtn);
+        });
+    }
+
+    async function loadAndRenderKillList() {
+        updateStatus(killListStatusMessage, 'Loading kill list...', 'status-loading');
+        try {
+            const data = await apiRequest('list_kill_list');
+            renderKillListTable(data.pids || []);
+            updateStatus(killListStatusMessage, 'Kill list loaded.', 'status-success');
+        } catch (error) {
+            renderKillListTable([]);
+            updateStatus(killListStatusMessage, `Error loading kill list: ${error.message}`, 'status-error');
+        }
+    }
+
+    function openKillListModal() {
+        if (killListModal) {
+            loadAndRenderKillList(); // This will set initial status (loading, then success/error)
+            killListModal.style.display = 'block';
+        }
+    }
+
+    function closeKillListModal() {
+        if (killListModal) {
+            killListModal.style.display = 'none';
+            if (killListStatusMessage) killListStatusMessage.textContent = ''; // Clear on close
+        }
+    }
+
+    async function removeFromKillList(pid, rowElement) {
+        // Note: `apiRequest` on error will update `processStatusMessage`, not `killListStatusMessage`.
+        // We need to handle errors specifically for `killListStatusMessage` here.
+        try {
+            const data = await apiRequest('remove_kill_list', { pid });
+            updateStatus(killListStatusMessage, data.message || `Process ${pid} removed from kill list.`, 'status-success');
+            loadAndRenderKillList(); // This will refresh the list and reset killListStatusMessage to "Kill list loaded."
+        } catch (error) {
+            // Override the general processStatusMessage update from apiRequest for this specific action
+            updateStatus(killListStatusMessage, `Error removing process ${pid}: ${error.message}`, 'status-error');
+        }
+    }
+
+    // --- Trigger Kill Loop ---
+    async function triggerKillLoop() {
+        if (!killLoopStatusOutput) return;
+        updateStatus(killLoopStatusOutput, 'Running kill loop check...', 'status-loading');
+        try {
+            const data = await apiRequest('kill_loop_check');
+            let htmlOutput = `<strong>Kill Loop Check Completed:</strong> ${data.message || "Processed."}<br>`;
+            if (data.results && data.results.length > 0) {
+                htmlOutput += '<ul>';
+                data.results.forEach(result => {
+                    htmlOutput += `<li>PID ${result.pid}: ${result.status}`;
+                    if (result.name) htmlOutput += ` (${result.name})`;
+                    if (result.message && result.status === 'error') htmlOutput += ` - ${result.message}`;
+                    htmlOutput += '</li>';
+                });
+                htmlOutput += '</ul>';
+            } else {
+                 htmlOutput += 'No processes were targeted or the kill list was empty.';
+            }
+            killLoopStatusOutput.innerHTML = htmlOutput; // Set innerHTML for list
+            killLoopStatusOutput.className = data.results && data.results.some(r => r.status === 'killed' || r.status === 'access_denied' || r.status === 'error') ? 'status-info' : 'status-success';
+
+            fetchProcesses();
+        } catch (error) {
+            updateStatus(killLoopStatusOutput, `Error triggering kill loop: ${error.message}`, 'status-error');
+        }
+    }
+
+    // --- Event Listeners ---
+    function initializeEventListeners() {
+        if (refreshProcessesBtn) refreshProcessesBtn.addEventListener('click', fetchProcesses);
+        else console.error("Refresh button not found");
+
+        if (openKillListModalBtn) openKillListModalBtn.addEventListener('click', openKillListModal);
+        else console.error("Open Kill List Modal button not found");
+
+        if (closeKillListModalBtn) closeKillListModalBtn.addEventListener('click', closeKillListModal);
+        else console.error("Close Kill List Modal button not found");
+
+        if (triggerKillLoopBtn) triggerKillLoopBtn.addEventListener('click', triggerKillLoop);
+        else console.error("Trigger Kill Loop button not found");
+
+        window.addEventListener('click', (event) => {
+            if (event.target === killListModal) {
+                closeKillListModal();
+            }
+        });
+    }
+
+    // --- Initial Load ---
+    initializeEventListeners();
     fetchProcesses();
-    setInterval(fetchProcesses, 7000);
+    setInterval(fetchProcesses, REFRESH_INTERVAL);
 });

--- a/static/index.html
+++ b/static/index.html
@@ -3,24 +3,90 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AppZap</title>
+    <title>AppZap Process Manager</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>AppZap Process Manager</h1>
-    <table id="proc-table">
-        <thead>
-            <tr>
-                <th>PID</th>
-                <th>Name</th>
-                <th>CPU %</th>
-                <th>MEM %</th>
-                <th>User</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+    <header>
+        <h1>AppZap Process Manager</h1>
+    </header>
+
+    <main>
+        <section id="controls">
+            <button id="refresh-processes-btn">Refresh Processes</button>
+            <button id="open-kill-list-modal-btn">Manage Kill List</button>
+            <button id="trigger-kill-loop-btn">Run Kill Loop Check</button>
+        </section>
+
+        <section id="process-viewer">
+            <h2>Running Processes</h2>
+            <div id="process-table-container">
+                <table id="process-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>PID</th>
+                            <th>User</th>
+                            <th>CPU %</th>
+                            <th>Memory %</th>
+                            <th>Net I/O (In/Out KB)</th>
+                            <th>Parent PID</th>
+                            <th>Command Line</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="process-list-body">
+                        <!-- Process data will be populated here by JavaScript -->
+                        <tr><td colspan="9">Loading processes...</td></tr>
+                    </tbody>
+                </table>
+            </div>
+            <div id="process-status-message"></div> <!-- For messages like errors or loading -->
+        </section>
+
+        <section id="kill-loop-status-section">
+            <h2>Kill Loop Check Status</h2>
+            <div id="kill-loop-status-output">
+                <!-- Status from kill_loop_check will appear here -->
+            </div>
+        </section>
+
+        <!-- Modal for Managing Kill List -->
+        <div id="kill-list-modal" class="modal">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2>Manage Kill List</h2>
+                    <span class="close-button" id="close-kill-list-modal-btn">&times;</span>
+                </div>
+                <div class="modal-body">
+                    <p>Processes in this list will be targeted by the "Kill Loop Check". PIDs for processes that no longer exist are automatically removed during the check.</p>
+                    <div id="kill-list-table-container">
+                        <table id="kill-list-table">
+                            <thead>
+                                <tr>
+                                    <th>PID</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="kill-list-body">
+                                <!-- Kill list PIDs will be populated here -->
+                                <tr><td colspan="2">Loading kill list...</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div id="kill-list-status-message"></div> <!-- For messages like errors or loading kill list -->
+                </div>
+                <div class="modal-footer">
+                    <p>Add PIDs to this list via the "Add to Kill List" button in the main process table.</p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <p>&copy; AppZap Process Manager</p>
+    </footer>
+
     <script src="app.js"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,22 +1,305 @@
+/* General Body and Typography */
 body {
-    font-family: Arial, sans-serif;
-    margin: 20px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f7f6;
+    color: #333;
+    font-size: 16px;
 }
 
-#proc-table {
+header {
+    background-color: #2c3e50; /* Dark blue-grey */
+    color: #ecf0f1; /* Light grey text */
+    padding: 1rem 0;
+    text-align: center;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+header h1 {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 500;
+}
+
+main {
+    max-width: 1300px; /* Slightly wider for more content */
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+section {
+    background-color: #ffffff;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.08);
+}
+
+h2 {
+    margin-top: 0;
+    color: #2c3e50;
+    border-bottom: 2px solid #3498db; /* Blue accent */
+    padding-bottom: 0.5rem;
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+}
+
+/* Controls Section */
+#controls {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background-color: #ecf0f1; /* Light grey background for control bar */
+    border-radius: 8px;
+    flex-wrap: wrap;
+}
+
+/* Table Styling */
+.table-container { /* Used in index.html */
+    overflow-x: auto;
+}
+
+table#process-table, table#kill-list-table {
     width: 100%;
     border-collapse: collapse;
+    margin-top: 1rem;
 }
 
-#proc-table th, #proc-table td {
-    border: 1px solid #ccc;
-    padding: 4px 8px;
+table#process-table th, table#process-table td,
+table#kill-list-table th, table#kill-list-table td {
+    padding: 0.8rem 1rem; /* Increased padding */
+    border: 1px solid #dfe6e9; /* Lighter border */
+    text-align: left;
+    vertical-align: middle;
+    font-size: 0.9rem;
+    white-space: nowrap; /* Prevent text wrapping in cells initially */
 }
 
-#proc-table th {
-    background-color: #f0f0f0;
+table#process-table td:nth-child(1), /* Name */
+table#process-table td:nth-child(8) { /* Command Line */
+    white-space: normal; /* Allow wrapping for these specific columns */
+    word-break: break-all; /* Break long words if necessary */
 }
 
-button.kill {
-    color: red;
+
+table#process-table thead, table#kill-list-table thead {
+    background-color: #3498db;
+    color: #ffffff;
+}
+
+table#process-table thead th, table#kill-list-table thead th {
+    font-weight: 600; /* Slightly bolder */
+}
+
+table#process-table tbody tr:nth-child(even),
+table#kill-list-table tbody tr:nth-child(even) {
+    background-color: #f8f9fa; /* Very light grey for even rows */
+}
+
+table#process-table tbody tr:hover,
+table#kill-list-table tbody tr:hover {
+    background-color: #e9ecef; /* Slightly darker grey on hover */
+}
+
+/* Button Styling */
+button, .action-btn {
+    padding: 0.6rem 1.2rem; /* More horizontal padding */
+    border: none;
+    border-radius: 5px; /* Slightly more rounded */
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: background-color 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
+    background-color: #3498db; /* Default blue */
+    color: white;
+    margin-right: 8px;
+    margin-bottom: 5px; /* For wrapped buttons */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+button:hover, .action-btn:hover {
+    opacity: 0.9;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+}
+
+button:active, .action-btn:active {
+    transform: translateY(1px); /* Slight press effect */
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+#refresh-processes-btn { background-color: #2ecc71; } /* Green */
+#open-kill-list-modal-btn { background-color: #f39c12; } /* Orange */
+#trigger-kill-loop-btn { background-color: #e74c3c; } /* Red */
+
+.kill-btn { background-color: #c0392b; padding: 0.4rem 0.8rem; font-size: 0.85rem;} /* Darker Red */
+.add-kill-list-btn { background-color: #27ae60; padding: 0.4rem 0.8rem; font-size: 0.85rem;} /* Darker Green */
+.remove-kill-list-btn { background-color: #7f8c8d; padding: 0.4rem 0.8rem; font-size: 0.85rem;} /* Grey */
+
+
+/* Modal Styling */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.5); /* Slightly darker overlay */
+}
+
+.modal-content {
+    background-color: #ffffff;
+    margin: 8% auto; /* Adjusted margin */
+    padding: 25px;
+    border: none; /* Removed border, rely on shadow */
+    width: 70%;
+    max-width: 650px;
+    border-radius: 10px; /* More rounded */
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.25);
+    animation: fadeInModal 0.4s cubic-bezier(0.25, 0.8, 0.25, 1); /* Smoother animation */
+}
+
+@keyframes fadeInModal {
+    from { opacity: 0; transform: translateY(-30px) scale(0.95); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.modal-header {
+    padding: 0 0 1rem 0; /* Remove side padding */
+    border-bottom: 1px solid #e9ecef;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: #2c3e50;
+    border-bottom: none;
+}
+
+.close-button {
+    color: #95a5a6; /* Lighter grey */
+    font-size: 30px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: color 0.2s;
+}
+
+.close-button:hover, .close-button:focus { color: #2c3e50; }
+
+.modal-body { padding: 1.5rem 0; } /* More vertical padding */
+.modal-footer {
+    padding: 1rem 0 0 0;
+    border-top: 1px solid #e9ecef;
+    text-align: right;
+    font-size: 0.9rem;
+    color: #7f8c8d;
+}
+.modal-footer p { margin: 0; }
+
+
+/* Process Row Color-Coding (Placeholders for JS to add) */
+.process-row-system td { /* Example: owned by root */
+    color: #c0392b;
+    /* font-weight: 500; */ /* Optional: makes it stand out more */
+}
+.process-row-user td { /* Example: owned by the same user as the web script (if distinguishable) */
+    /* color: #27ae60; */ /* Optional: if you want to highlight "own" processes */
+}
+.process-row-other-user td { /* Example: owned by other non-root users */
+    color: #555; /* Slightly darker than default for differentiation */
+}
+
+/* Temporary highlights for actions */
+.row-highlight-success td {
+    background-color: #d1e7dd !important; /* Bootstrap's success light green */
+    transition: background-color 1s ease-out;
+}
+.row-highlight-error td {
+    background-color: #f8d7da !important; /* Bootstrap's danger light red */
+    transition: background-color 1s ease-out;
+}
+.row-highlight-info td {
+    background-color: #cff4fc !important; /* Bootstrap's info light blue */
+    transition: background-color 1s ease-out;
+}
+
+
+/* Status and Error Messages */
+#process-status-message,
+#kill-list-status-message,
+#kill-loop-status-output {
+    padding: 0.8rem 1rem;
+    margin-top: 1rem;
+    border-radius: 5px;
+    font-size: 0.95rem;
+    border: 1px solid transparent;
+}
+
+#kill-loop-status-output { margin-bottom: 1rem; }
+#kill-loop-status-output ul { padding-left: 20px; margin: 0.5rem 0 0 0; }
+#kill-loop-status-output li { margin-bottom: 0.4rem; }
+
+.status-success { background-color: #d1e7dd; color: #0f5132; border-color: #badbcc;}
+.status-error { background-color: #f8d7da; color: #842029; border-color: #f5c2c7;}
+.status-info { background-color: #cff4fc; color: #055160; border-color: #b6effb;}
+.status-loading { background-color: #e2e3e5; color: #41464b; border-color: #d3d6d8;}
+
+
+/* Footer */
+footer {
+    text-align: center;
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background-color: #e9ecef; /* Lighter footer */
+    color: #495057; /* Darker grey text for footer */
+    font-size: 0.9rem;
+    border-top: 1px solid #dee2e6;
+}
+footer p { margin: 0; }
+
+/* Responsive adjustments */
+@media (max-width: 992px) { /* For tablets and larger phones */
+    table#process-table th, table#process-table td,
+    table#kill-list-table th, table#kill-list-table td {
+        white-space: normal; /* Allow wrapping for all cells on smaller screens */
+        word-break: break-word;
+    }
+}
+
+@media (max-width: 768px) {
+    body { font-size: 15px; }
+    main { padding: 0.8rem; }
+    section, #controls { padding: 1rem; }
+    header h1 { font-size: 1.7rem; }
+    h2 { font-size: 1.3rem; }
+
+    #controls { flex-direction: column; }
+    #controls button { width: 100%; margin-right: 0; margin-bottom: 0.6rem; }
+
+    .modal-content { width: 85%; margin: 15% auto; }
+    table#process-table th, table#process-table td,
+    table#kill-list-table th, table#kill-list-table td {
+        padding: 0.6rem; font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 480px) { /* For small smartphones */
+    body { font-size: 14px; }
+    .modal-content { width: 95%; margin: 20% auto; padding: 15px; }
+    header h1 { font-size: 1.5rem; }
+    h2 { font-size: 1.2rem; }
+     table#process-table th, table#process-table td,
+    table#kill-list-table th, table#kill-list-table td {
+        padding: 0.4rem; font-size: 0.8rem;
+    }
+    button, .action-btn { padding: 0.5rem 0.8rem; font-size: 0.85rem; }
 }


### PR DESCRIPTION
This commit introduces the initial version of AppZap, a web-based macOS process manager.

Key features implemented:
- Backend (`cgi-bin/sysinfo.py`):
    - Lists processes with details (PID, name, CPU, memory, user, etc.) via `action=list`.
    - Kills processes via `action=kill&pid=PID`.
    - Manages a persistent kill list (`kill_list.json`) with actions:
        - `add_kill_list&pid=PID`
        - `remove_kill_list&pid=PID` - `list_kill_list` (to view the list)
    - `kill_loop_check` action to enforce the kill list.
    - All communication is via JSON.
- Frontend (`static/`):
    - `index.html`: Main application page structure.
    - `app.js`:
        - Fetches and displays process data every 7 seconds.
        - Allows killing processes and adding/removing from the kill list via UI buttons. - Modal dialog for managing the kill list. - "Trigger Kill Loop" button. - Uses on-page status messages for your feedback.
    - `style.css`: - Basic styling for tables, buttons, modal, and overall layout. - Color-coding for "root" processes. - Responsive design elements.

The application structure follows the PLAN.md, and core functionalities from README.md have been implemented.